### PR TITLE
  Fix message deserialization to preserve the expected Go type

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -2,6 +2,7 @@ package gosumer
 
 import (
 	"encoding/json"
+	"reflect"
 )
 
 type Transport interface {
@@ -10,11 +11,30 @@ type Transport interface {
 }
 
 func formatMessage(message string, msg any) (any, error) {
-	if err := json.Unmarshal([]byte(message), &msg); err != nil {
-		return msg, err
+	msgType := reflect.TypeOf(msg)
+	if msgType == nil {
+		var formatted any
+		if err := json.Unmarshal([]byte(message), &formatted); err != nil {
+			return nil, err
+		}
+
+		return formatted, nil
 	}
 
-	return msg, nil
+	target := reflect.New(msgType)
+	if msgType.Kind() == reflect.Ptr {
+		target = reflect.New(msgType.Elem())
+	}
+
+	if err := json.Unmarshal([]byte(message), target.Interface()); err != nil {
+		return nil, err
+	}
+
+	if msgType.Kind() == reflect.Ptr {
+		return target.Interface(), nil
+	}
+
+	return target.Elem().Interface(), nil
 }
 
 func Listen(transport Transport, fn process, message any, sec int) error {

--- a/transport_test.go
+++ b/transport_test.go
@@ -8,18 +8,42 @@ import (
 )
 
 func TestFormatMessage(t *testing.T) {
-	var msg any
-
 	jsonData := `{"id": 1, "name": "John Doe"}`
 
-	_, err := formatMessage(jsonData, &msg)
+	type Payload struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	formatted, err := formatMessage(jsonData, Payload{})
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 
+	msg, ok := formatted.(Payload)
+	if !ok {
+		t.Fatalf("Expected payload type, got %T", formatted)
+	}
+
+	assert.Equal(t, 1, msg.ID)
+	assert.Equal(t, "John Doe", msg.Name)
+
+	formattedPtr, err := formatMessage(jsonData, &Payload{})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	msgPtr, ok := formattedPtr.(*Payload)
+	if !ok {
+		t.Fatalf("Expected *Payload type, got %T", formattedPtr)
+	}
+
+	assert.Equal(t, 1, msgPtr.ID)
+	assert.Equal(t, "John Doe", msgPtr.Name)
+
 	invalidJsonData := `{"id": 1, "name": "John Doe"`
 
-	_, err = formatMessage(invalidJsonData, &msg)
+	_, err = formatMessage(invalidJsonData, Payload{})
 	if err == nil {
 		t.Errorf("Expected an error for invalid JSON data, but got none")
 	}


### PR DESCRIPTION
  ## Why

  This package is intended to let Symfony Messenger payloads be consumed in Go using regular Go message types.

  Before this change, JSON payloads were not reliably deserialized into the caller-provided type.
  As a result, the handler contract was less predictable than the API suggested.

  This patch improves that behavior by making deserialization align more closely with the expected API.

  ## What changed

  - preserve the concrete type passed to `formatMessage`
  - support both struct and pointer message inputs
  - add focused tests to cover both cases
